### PR TITLE
Disallow 0 minutes timer setting

### DIFF
--- a/app/src/main/java/com/luis_santiago/flagquizapp/ui/FragmentPrefrences.java
+++ b/app/src/main/java/com/luis_santiago/flagquizapp/ui/FragmentPrefrences.java
@@ -47,6 +47,11 @@ public class FragmentPrefrences extends Fragment {
     private SeekBar.OnSeekBarChangeListener onSeekBarChangeListener = new SeekBar.OnSeekBarChangeListener() {
         @Override
         public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+            // Disallow 0 minutes
+            if (progress == 0) {
+                progress = 1;
+                seekBar.setProgress(progress);
+            }
             Keys.MINUTE_TO_START = progress;
             Keys.UPDATE_PERMISSON = true;
             Log.e("Setting", "Minutes are being changed" + Keys.MINUTE_TO_START);


### PR DESCRIPTION
Hi @Legendarywicho ,
I have made changes to FragmentPreferences.
Seekbar used to seek till 0, but we should disallow it, right ?
There are a few bugs. We will fix those in the future builds.